### PR TITLE
コメントが5つ付いたトピックからサブトピックを2つ生成するサンプル完成

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -36,7 +36,7 @@ export const postTopicAndComment = async (postData: {
 	return data;
 };
 
-export const getTopicAndComments = async () => {
+export const getTopicAndComments = async (topicId: string) => {
 	try {
 		const response = await fetch(`${apiUrl}/get-topic-and-comment`);
 		if (!response.ok) {
@@ -51,11 +51,16 @@ export const getTopicAndComments = async () => {
 		// return data.map((item) =>
 		// 	typeof item === "object" && item.comment ? item.comment : item,
 		// );
-		return data.map((item) =>
-			typeof item === "object" && item.comments && item.topic
-				? { id: item.id, topic: item.topic, comments: item.comments }
-				: item,
-		);
+		return data
+			.map((item) =>
+				typeof item === "object" && item.comments && item.topic
+					? { id: item.id, topic: item.topic, comments: item.comments }
+					: item,
+			)
+			.filter(
+				(item: { id: string; topic: string; comments: string[] }) =>
+					item.id === topicId,
+			);
 	} catch (error) {
 		console.error("Failed to fetch topic and comments:", error);
 		throw error;

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -52,8 +52,8 @@ export const getTopicAndComments = async () => {
 		// 	typeof item === "object" && item.comment ? item.comment : item,
 		// );
 		return data.map((item) =>
-			typeof item === "object" && item.comment && item.topic
-				? { id: item.id, topic: item.topic, comment: item.comment }
+			typeof item === "object" && item.comments && item.topic
+				? { id: item.id, topic: item.topic, comments: item.comments }
 				: item,
 		);
 	} catch (error) {

--- a/src/api/gemini.ts
+++ b/src/api/gemini.ts
@@ -7,8 +7,8 @@ export async function fetchSummaryFromGemini(
 
 	const prompt = `
 あなたは優秀な要約AIです。
-以下のトピック「${topicUrl}」に関する複数人の投稿があります。
-それらを1つの要約文にしてください。
+トピック「${topicUrl}」に関する複数人の投稿があります。
+このトピックのURLにアクセスして記事を読み、複数人の投稿を1つの要約文にしてください。
 
 投稿：
 ${topics.flatMap((topic) => topic.comments.map((p, i) => `投稿${i + 1}：${p}`)).join("\n")}

--- a/src/api/topic.ts
+++ b/src/api/topic.ts
@@ -1,4 +1,5 @@
 import { v4 as uuidv4 } from "uuid";
+import commentsData from "../data/comments.json";
 import { summarizeArticleFromURL } from "./gemini";
 
 export async function getTopic(): Promise<
@@ -46,7 +47,7 @@ export async function getTopic(): Promise<
 		const topicSummary = await summarizeArticleFromURL(url, title);
 		const id = uuidv4();
 
-		return [
+		const apiTopics = [
 			{
 				id: id,
 				url: url,
@@ -54,6 +55,24 @@ export async function getTopic(): Promise<
 				summary: topicSummary,
 			},
 		];
+
+		// topics.jsonからトピックをロード
+		const commentTopics = commentsData.topics.map(
+			(topic: {
+				id: string;
+				name: string;
+				comments: string[];
+				subTopic: { id: string; name: string; comments: never[] }[];
+			}) => ({
+				id: topic.id,
+				url: "",
+				title: topic.name,
+				summary: "",
+			}),
+		);
+
+		// APIとtopics.jsonからのトピックを結合
+		return [...apiTopics, ...commentTopics];
 	} catch (error) {
 		console.error("Error fetching topics:", error);
 		return [];

--- a/src/api/topic.ts
+++ b/src/api/topic.ts
@@ -3,7 +3,13 @@ import commentsData from "../data/comments.json";
 import { summarizeArticleFromURL } from "./gemini";
 
 export async function getTopic(): Promise<
-	{ id: string; url: string; title: string; summary: string }[]
+	{
+		id: string;
+		url: string;
+		title: string;
+		summary: string;
+		subtopics: { id: string; title: string; summary: string }[];
+	}[]
 > {
 	try {
 		// API URL
@@ -53,6 +59,7 @@ export async function getTopic(): Promise<
 				url: url,
 				title: title,
 				summary: topicSummary,
+				subtopics: [],
 			},
 		];
 
@@ -67,7 +74,12 @@ export async function getTopic(): Promise<
 				id: topic.id,
 				url: "",
 				title: topic.name,
-				summary: "",
+				summary: topic.comments.join(", "),
+				subtopics: topic.subTopic.map((sub) => ({
+					id: sub.id,
+					title: sub.name,
+					summary: sub.comments.join(", "),
+				})),
 			}),
 		);
 

--- a/src/pages/Summary.tsx
+++ b/src/pages/Summary.tsx
@@ -37,7 +37,7 @@ export const Summary: React.FC = () => {
 			}
 
 			// const comments = await getComments();
-			const topicAndComments = await getTopicAndComments();
+			const topicAndComments = await getTopicAndComments(topic.id);
 			if (topic.title === "") {
 				throw new Error("トピックが取得できていません");
 			}
@@ -62,12 +62,9 @@ export const Summary: React.FC = () => {
 			// return await fetchSummaryFromGemini(topic.url, topicAndComments);
 			// console.log("matchingComment", matchingComment);
 			console.log("topic.url", topic.url);
-			return await fetchSummaryFromGemini(
-				topic.url,
-				matchingComments
-					? [{ name: topic.title, comments: matchingComments }]
-					: [],
-			);
+			return await fetchSummaryFromGemini(topic.url, [
+				{ name: topic.title, comments: matchingComments || [] },
+			]);
 		},
 		{
 			refreshInterval: 10000, // 10秒ごとにポーリング

--- a/src/pages/Summary.tsx
+++ b/src/pages/Summary.tsx
@@ -1,9 +1,9 @@
 import type React from "react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import useSWR from "swr";
 import { getTopicAndComments, postTopicAndComment } from "../api/api";
 import { fetchSummaryFromGemini } from "../api/gemini"; // 追加：Gemini関数のインポート
-import { getTopic } from "../api/topic";
+// import { getTopic } from "../api/topic";
 
 type postData = {
 	id: string;
@@ -13,25 +13,15 @@ type postData = {
 
 export const Summary: React.FC = () => {
 	const [comment, setComment] = useState("");
-	const [topicId, setTopicId] = useState("");
-	const [topicUrl, setTopicUrl] = useState("");
-	const [topicTitle, setTopicTitle] = useState("");
-	const [topicSummary, setTopicSummary] = useState("");
+	const [topic, setTopic] = useState({
+		id: "No ID",
+		url: "No URL",
+		title: "No Title",
+		summary: "No Summary",
+	});
 	const [topicLevel, setTopicLevel] = useState(0);
-
-	const { error: topicError } = useSWR(
-		"/topic",
-		async () => {
-			const topics = await getTopic();
-			setTopicId(topics.length > 0 ? topics[0].id : "No ID");
-			setTopicUrl(topics.length > 0 ? topics[0].url : "No URL");
-			setTopicTitle(topics.length > 0 ? topics[0].title : "No Title");
-			setTopicSummary(topics.length > 0 ? topics[0].summary : "No Summary");
-		},
-		{
-			refreshInterval: 3600000, // 3600秒ごとにポーリング
-		},
-	);
+	// const [summary, setSummary] = useState<string | null>(null);
+	// const [summaryError, setSummaryError] = useState<Error | null>(null);
 
 	// SWRを使って要約を定期取得（10秒ごと）
 	const { data: summary, error: summaryError } = useSWR(
@@ -39,19 +29,19 @@ export const Summary: React.FC = () => {
 		async () => {
 			// const comments = await getComments();
 			const topicAndComments = await getTopicAndComments();
-			if (topicTitle === "") {
+			if (topic.title === "") {
 				throw new Error("トピックが取得できていません");
 			}
 			// return await fetchSummaryFromGemini(topic, comments);
 			setTopicLevel(() => {
 				const matchingTopic = topicAndComments.find(
-					(topic) => topic.id === topicId,
+					(gotTopic) => gotTopic.id === topic.id,
 				);
 				return matchingTopic
 					? Math.min(4, Math.floor(matchingTopic.comments.length / 3))
 					: 0;
 			});
-			return await fetchSummaryFromGemini(topicUrl, topicAndComments);
+			return await fetchSummaryFromGemini(topic.url, topicAndComments);
 		},
 		{
 			refreshInterval: 10000, // 10秒ごとにポーリング
@@ -65,49 +55,56 @@ export const Summary: React.FC = () => {
 	const handleCommentSubmit = async () => {
 		setComment("");
 		const postData: postData = {
-			id: topicId,
-			topic: topicTitle,
+			id: topic.id,
+			topic: topic.title,
 			comment: comment,
 		};
 		await postTopicAndComment(postData); // トピックとコメントを送信（即時要約更新なし）
 	};
 
+	// TopicListから渡されたトピック情報を受け取る
+	// Summaryコンポーネントがマウントされたときに一度だけ実行
+	useEffect(() => {
+		const topicData = sessionStorage.getItem("topic");
+		if (topicData) {
+			const parsedTopic = JSON.parse(topicData);
+			setTopic(parsedTopic);
+		}
+	}, []); // 空の依存配列でマウント時のみ実行
+
 	return (
 		// メインコンテナ
 		<div className="summary-container h-screen w-screen overflow-auto p-8 bg-gradient-to-br from-gray-100 to-gray-200 font-sans">
-			<h1 className="text-4xl font-extrabold text-gray-800 tracking-tight border-b pb-4 border-gray-300">
+			<h1 className="text-4xl font-extrabold text-gray-800 tracking-tight border-b pb-4 mb-4 border-gray-300">
 				🌟 Summary of Comments on Topic
 			</h1>
 
 			{/* トピック表示 */}
-			<div className="topic bg-white p-6 rounded-lg shadow-md hover:shadow-lg transition duration-300">
+			<div className="topic bg-white p-6 mb-4 rounded-lg shadow-md hover:shadow-lg transition duration-300">
 				<h2 className="text-2xl font-semibold text-gray-700 mb-2">📌 Topic</h2>
-				{topicError ? (
-					<p className="text-red-600">⚠️ トピックの取得に失敗しました。</p>
-				) : (
-					<>
-						<p className="text-black text-lg leading-relaxed">
-							トピックID:
-							{topicId || "（トピックID取得中）"}
-						</p>
-						<p className="text-black text-lg leading-relaxed">
-							トピックURL:
-							{topicUrl || "（トピックURL取得中）"}
-						</p>
-						<p className="text-black text-lg leading-relaxed">
-							トピックタイトル:
-							{topicTitle || "（トピックタイトル取得中）"}
-						</p>
-						<p className="text-black text-lg leading-relaxed">
-							トピックサマリ:
-							{topicSummary || "（トピックサマリ取得中）"}
-						</p>
-					</>
-				)}
+				{/* topicErrorを削除 */}
+				<>
+					<p className="text-black text-lg leading-relaxed">
+						トピックID:
+						{topic.id || "（トピックID取得中）"}
+					</p>
+					<p className="text-black text-lg leading-relaxed">
+						トピックURL:
+						{topic.url || "（トピックURL取得中）"}
+					</p>
+					<p className="text-black text-lg leading-relaxed">
+						トピックタイトル:
+						{topic.title || "（トピックタイトル取得中）"}
+					</p>
+					<p className="text-black text-lg leading-relaxed">
+						トピックサマリ:
+						{topic.summary || "（トピックサマリ取得中）"}
+					</p>
+				</>
 			</div>
 
 			{/* コメント入力フォーム */}
-			<div className="comment bg-white p-6 rounded-lg shadow-md hover:shadow-lg transition duration-300">
+			<div className="comment bg-white p-6 mb-4 rounded-lg shadow-md hover:shadow-lg transition duration-300">
 				<h2 className="text-2xl font-semibold text-gray-700 mb-3">
 					💬 Comment
 				</h2>
@@ -129,7 +126,7 @@ export const Summary: React.FC = () => {
 			</div>
 
 			{/* 要約表示 */}
-			<div className="summary bg-red-50 border-l-4 border-red-400 p-6 rounded-lg shadow-inner">
+			<div className="summary bg-red-50 border-l-4 border-red-400 p-6 mb-4 rounded-lg shadow-inner">
 				<h2 className="text-2xl font-semibold text-red-600 mb-3">📝 要約</h2>
 				<div className="text-gray-700 mb-2">topicLevel: {topicLevel}</div>
 

--- a/src/pages/Summary.tsx
+++ b/src/pages/Summary.tsx
@@ -13,7 +13,13 @@ type postData = {
 
 export const Summary: React.FC = () => {
 	const [comment, setComment] = useState("");
-	const [topic, setTopic] = useState({
+	const [topic, setTopic] = useState<{
+		id: string;
+		url: string;
+		title: string;
+		summary: string;
+		subtopics?: { id: string; title: string; summary: string }[];
+	} | null>({
 		id: "No ID",
 		url: "No URL",
 		title: "No Title",
@@ -37,8 +43,11 @@ export const Summary: React.FC = () => {
 			}
 
 			// const comments = await getComments();
+			if (!topic) {
+				throw new Error("No topic selected");
+			}
 			const topicAndComments = await getTopicAndComments(topic.id);
-			if (topic.title === "") {
+			if (!topic.title) {
 				throw new Error("トピックが取得できていません");
 			}
 			// return await fetchSummaryFromGemini(topic, comments);
@@ -78,8 +87,8 @@ export const Summary: React.FC = () => {
 	const handleCommentSubmit = async () => {
 		setComment("");
 		const postData: postData = {
-			id: topic.id,
-			topic: topic.title,
+			id: topic ? topic.id : "no-topic",
+			topic: topic ? topic.title : "no-topic",
 			comment: comment,
 		};
 		await postTopicAndComment(postData); // トピックとコメントを送信（即時要約更新なし）
@@ -109,19 +118,19 @@ export const Summary: React.FC = () => {
 				<>
 					<p className="text-black text-lg leading-relaxed">
 						トピックID:
-						{topic.id || "（トピックID取得中）"}
+						{topic ? topic.id : "（トピックID取得中）"}
 					</p>
 					<p className="text-black text-lg leading-relaxed">
 						トピックURL:
-						{topic.url || "（トピックURL取得中）"}
+						{topic ? topic.url : "（トピックURL取得中）"}
 					</p>
 					<p className="text-black text-lg leading-relaxed">
 						トピックタイトル:
-						{topic.title || "（トピックタイトル取得中）"}
+						{topic ? topic.title : "（トピックタイトル取得中）"}
 					</p>
 					<p className="text-black text-lg leading-relaxed">
 						トピックサマリ:
-						{topic.summary || "（トピックサマリ取得中）"}
+						{topic ? topic.summary : "（トピックサマリ取得中）"}
 					</p>
 				</>
 			</div>

--- a/src/pages/TopicList.tsx
+++ b/src/pages/TopicList.tsx
@@ -32,6 +32,7 @@ export const TopicList: React.FC = () => {
 							url: string;
 							title: string;
 							summary: string;
+							subtopics: { id: string; title: string; summary: string }[];
 						}) => (
 							<div
 								key={topic.id}
@@ -69,6 +70,45 @@ export const TopicList: React.FC = () => {
 								<p className="text-black text-lg leading-relaxed">
 									トピックサマリ: {topic.summary}
 								</p>
+								{topic.subtopics?.map((subtopic) => (
+									<div
+										key={subtopic.id}
+										className="subtopic bg-gray-100 p-4 rounded-lg shadow-md hover:shadow-lg transition duration-300 mb-2 ml-4 cursor-pointer"
+										onClick={() => {
+											sessionStorage.setItem("topic", JSON.stringify(subtopic));
+											window.location.href = "/summary";
+										}}
+										onKeyDown={(e) => {
+											if (e.key === "Enter" || e.key === " ") {
+												sessionStorage.setItem(
+													"topic",
+													JSON.stringify(subtopic),
+												);
+												window.location.href = "/summary";
+											}
+										}}
+									>
+										<a
+											href="/summary"
+											onClick={() =>
+												sessionStorage.setItem(
+													"topic",
+													JSON.stringify(subtopic),
+												)
+											}
+										>
+											<h3 className="text-xl font-semibold text-gray-600 mb-1 hover:text-blue-500">
+												{subtopic.title}
+											</h3>
+										</a>
+										<p className="text-black text-lg leading-relaxed">
+											サブトピックID: {subtopic.id}
+										</p>
+										<p className="text-black text-lg leading-relaxed">
+											サブトピックサマリ: {subtopic.summary}
+										</p>
+									</div>
+								))}
 							</div>
 						),
 					)}

--- a/src/pages/TopicList.tsx
+++ b/src/pages/TopicList.tsx
@@ -1,5 +1,4 @@
 import type React from "react";
-// import { useState } from "react";
 import useSWR from "swr";
 import { getTopic } from "../api/topic";
 
@@ -27,45 +26,52 @@ export const TopicList: React.FC = () => {
 				<p>Loading topics...</p>
 			) : (
 				<div className="mt-4">
-					{topics.map((topic) => (
-						<div
-							key={topic.id}
-							className="topic bg-white p-6 rounded-lg shadow-md hover:shadow-lg transition duration-300 mb-4 cursor-pointer"
-							onClick={() => {
-								sessionStorage.setItem("topic", JSON.stringify(topic));
-								window.location.href = "/summary";
-							}}
-							onKeyDown={(e) => {
-								if (e.key === "Enter" || e.key === " ") {
+					{topics.map(
+						(topic: {
+							id: string;
+							url: string;
+							title: string;
+							summary: string;
+						}) => (
+							<div
+								key={topic.id}
+								className="topic bg-white p-6 rounded-lg shadow-md hover:shadow-lg transition duration-300 mb-4 cursor-pointer"
+								onClick={() => {
 									sessionStorage.setItem("topic", JSON.stringify(topic));
 									window.location.href = "/summary";
-								}
-							}}
-						>
-							<a
-								href="/summary"
-								onClick={() =>
-									sessionStorage.setItem("topic", JSON.stringify(topic))
-								}
+								}}
+								onKeyDown={(e) => {
+									if (e.key === "Enter" || e.key === " ") {
+										sessionStorage.setItem("topic", JSON.stringify(topic));
+										window.location.href = "/summary";
+									}
+								}}
 							>
-								<h2 className="text-2xl font-semibold text-gray-700 mb-2 hover:text-blue-500">
-									{topic.title}
-								</h2>
-							</a>
-							<p className="text-black text-lg leading-relaxed">
-								トピックID: {topic.id}
-							</p>
-							<p className="text-black text-lg leading-relaxed">
-								トピックURL: {topic.url}
-							</p>
-							<p className="text-black text-lg leading-relaxed">
-								トピックタイトル: {topic.title}
-							</p>
-							<p className="text-black text-lg leading-relaxed">
-								トピックサマリ: {topic.summary}
-							</p>
-						</div>
-					))}
+								<a
+									href="/summary"
+									onClick={() =>
+										sessionStorage.setItem("topic", JSON.stringify(topic))
+									}
+								>
+									<h2 className="text-2xl font-semibold text-gray-700 mb-2 hover:text-blue-500">
+										{topic.title}
+									</h2>
+								</a>
+								<p className="text-black text-lg leading-relaxed">
+									トピックID: {topic.id}
+								</p>
+								<p className="text-black text-lg leading-relaxed">
+									トピックURL: {topic.url}
+								</p>
+								<p className="text-black text-lg leading-relaxed">
+									トピックタイトル: {topic.title}
+								</p>
+								<p className="text-black text-lg leading-relaxed">
+									トピックサマリ: {topic.summary}
+								</p>
+							</div>
+						),
+					)}
 				</div>
 			)}
 		</div>

--- a/src/pages/TopicList.tsx
+++ b/src/pages/TopicList.tsx
@@ -1,25 +1,16 @@
 import type React from "react";
-import { useState } from "react";
+// import { useState } from "react";
 import useSWR from "swr";
 import { getTopic } from "../api/topic";
 
 export const TopicList: React.FC = () => {
-	const [topicId, setTopicId] = useState("");
-	const [topicUrl, setTopicUrl] = useState("");
-	const [topicTitle, setTopicTitle] = useState("");
-	const [topicSummary, setTopicSummary] = useState("");
-
-	const { error: topicError } = useSWR(
+	const { data: topics, error: topicError } = useSWR(
 		"/topic-list",
 		async () => {
-			const topics = await getTopic();
-			setTopicId(topics.length > 0 ? topics[0].id : "No ID");
-			setTopicUrl(topics.length > 0 ? topics[0].url : "No URL");
-			setTopicTitle(topics.length > 0 ? topics[0].title : "No Title");
-			setTopicSummary(topics.length > 0 ? topics[0].summary : "No Summary");
+			return await getTopic();
 		},
 		{
-			refreshInterval: 3600000, // 3600秒ごとにポーリング
+			// refreshInterval: 3600000, // 3600秒ごとにポーリング
 		},
 	);
 
@@ -30,32 +21,53 @@ export const TopicList: React.FC = () => {
 				🌟 Topic List
 			</h1>
 
-			{/* トピック表示 */}
-			<div className="topic bg-white p-6 rounded-lg shadow-md hover:shadow-lg transition duration-300">
-				<h2 className="text-2xl font-semibold text-gray-700 mb-2">📌 Topic</h2>
-				{topicError ? (
-					<p className="text-red-600">⚠️ トピックの取得に失敗しました。</p>
-				) : (
-					<>
-						<p className="text-black text-lg leading-relaxed">
-							トピックID:
-							{topicId || "（トピックID取得中）"}
-						</p>
-						<p className="text-black text-lg leading-relaxed">
-							トピックURL:
-							{topicUrl || "（トピックURL取得中）"}
-						</p>
-						<p className="text-black text-lg leading-relaxed">
-							トピックタイトル:
-							{topicTitle || "（トピックタイトル取得中）"}
-						</p>
-						<p className="text-black text-lg leading-relaxed">
-							トピックサマリ:
-							{topicSummary || "（トピックサマリ取得中）"}
-						</p>
-					</>
-				)}
-			</div>
+			{topicError ? (
+				<p className="text-red-600">⚠️ トピックの取得に失敗しました。</p>
+			) : !topics ? (
+				<p>Loading topics...</p>
+			) : (
+				<div className="mt-4">
+					{topics.map((topic) => (
+						<div
+							key={topic.id}
+							className="topic bg-white p-6 rounded-lg shadow-md hover:shadow-lg transition duration-300 mb-4 cursor-pointer"
+							onClick={() => {
+								sessionStorage.setItem("topic", JSON.stringify(topic));
+								window.location.href = "/summary";
+							}}
+							onKeyDown={(e) => {
+								if (e.key === "Enter" || e.key === " ") {
+									sessionStorage.setItem("topic", JSON.stringify(topic));
+									window.location.href = "/summary";
+								}
+							}}
+						>
+							<a
+								href="/summary"
+								onClick={() =>
+									sessionStorage.setItem("topic", JSON.stringify(topic))
+								}
+							>
+								<h2 className="text-2xl font-semibold text-gray-700 mb-2 hover:text-blue-500">
+									{topic.title}
+								</h2>
+							</a>
+							<p className="text-black text-lg leading-relaxed">
+								トピックID: {topic.id}
+							</p>
+							<p className="text-black text-lg leading-relaxed">
+								トピックURL: {topic.url}
+							</p>
+							<p className="text-black text-lg leading-relaxed">
+								トピックタイトル: {topic.title}
+							</p>
+							<p className="text-black text-lg leading-relaxed">
+								トピックサマリ: {topic.summary}
+							</p>
+						</div>
+					))}
+				</div>
+			)}
 		</div>
 	);
 };

--- a/src/server.cjs
+++ b/src/server.cjs
@@ -44,6 +44,22 @@ app.post("/post-topic-and-comment", (req, res) => {
 
 	if (existingTopic) {
 		existingTopic.comments.push(comment);
+
+		// コメント数が5になったら subTopic を生成
+		if (existingTopic.comments.length === 5) {
+			existingTopic.subTopic = [
+				{
+					id: `${id}-sub1`,
+					name: `${existingTopic.name} - SubTopic 1`,
+					comments: [],
+				},
+				{
+					id: `${id}-sub2`,
+					name: `${existingTopic.name} - SubTopic 2`,
+					comments: [],
+				},
+			];
+		}
 	} else {
 		/** @type {Topic} */
 		const newTopic = {


### PR DESCRIPTION
`sessionStorage`を利用して無理やり実装（完成を優先）

## [コメントの多いトピックからサブトピックを生成](https://github.com/yif11/HiveTree/issues/52)について

>サブトピックは何世代まで生やすか

現状1世代のみ

>あるトピックからサブトピックを生やすとき，同時にいくつ生やすか

2つ

>コメントがいくつついたらサブトピックを生やすか

現状5つ

## TODO
- コメントをgeminiで要約して具体的なサブトピックを生成
- `TopicList.tsx`へのサブトピックの表示